### PR TITLE
Deprecate `s1:processing_datetime` in favor of `processing:datetime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `s1:processing_datetime` in favor of `processing:datetime`
+
 ### Removed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ The fields in the table below can be used in these parts of STAC documents:
 | s1:datatake_id                 | string    | e.g. `420895`                                                |
 | s1:instrument_configuration_ID | string    | e.g. `7`                                                     |
 | s1:orbit_source                | string    | e.g. `PREORB`                                                |
-| s1:processing_datetime         | string    | RFC3339 datetime in UTC                                      |
 | s1:product_identifier          | string    | e.g. `S1A_IW_GRDH_1SDV_20240318T153023_20240318T153035_053038_066C1F_F913` |
 | s1:product_timeliness          | string    | e.g. `NRT-3h`, `Fast-24h`                                    |
 | s1:resolution                  | string    | e.g. `high`                                                  |
 | s1:slice_number                | string    | e.g. `17`                                                    |
 | s1:total_slices                | string    | e.g. `17`                                                    |
+| s1:processing_datetime         | string    | **DEPRECATED** Use processing:datetime instead               |
 | s1:processing_level            | string    | **DEPRECATED** Use processing:level instead                  |
 | s1:shape                       | [integer] | **DEPRECATED** Use proj:shape instead                        |
 

--- a/examples/earthsearch-s1-grd.json
+++ b/examples/earthsearch-s1-grd.json
@@ -63,7 +63,7 @@
       12777
     ],
     "s1:product_identifier": "S1A_EW_GRDM_1SDH_20240325T094655_20240325T094811_053136_066FDB_411C",
-    "s1:processing_datetime": "2024-03-25T11:02:44.000000Z",
+    "processing:datetime": "2024-03-25T11:02:44.000000Z",
     "storage:platform": "AWS",
     "storage:region": "eu-central-1",
     "storage:requester_pays": true,
@@ -330,7 +330,7 @@
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sar/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/processing/v1.2.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/sentinel-1/v0.1.0/schema.json"

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -63,7 +63,6 @@
         {"required": ["s1:datatake_id"]},
         {"required": ["s1:instrument_configuration_ID"]},
         {"required": ["s1:orbit_source"]},
-        {"required": ["s1:processing_datetime"]},
         {"required": ["s1:product_identifier"]},
         {"required": ["s1:product_timeliness"]},
         {"required": ["s1:resolution"]},


### PR DESCRIPTION
Depends on https://github.com/stac-extensions/processing/pull/32